### PR TITLE
Respect installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,6 @@ add_subdirectory(test)
 
 install(DIRECTORY
 		${CMAKE_SOURCE_DIR}/include/
-		DESTINATION /usr/local/include/${PROJECT_NAME}
+		DESTINATION include/${PROJECT_NAME}
 		FILES_MATCHING PATTERN "*")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -130,9 +130,12 @@ externalproject_add(googletest
 		PREFIX googletest
 		GIT_REPOSITORY https://github.com/google/googletest
 		UPDATE_COMMAND ""
+		INSTALL_COMMAND ""
 )
-externalproject_get_property(googletest source_dir)
-include_directories("${source_dir}")
+externalproject_get_property(googletest source_dir binary_dir)
+include_directories("${source_dir}/googletest/include")
+include_directories("${source_dir}/googlemock/include")
+link_directories("${binary_dir}/lib")
 list(APPEND DEPS googletest)
 list(APPEND LIBS gtest gmock)
 
@@ -164,4 +167,4 @@ if (WIN32)
 	set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME} SUFFIX ".dll")
 endif()
 
-install(TARGETS ${PROJECT_NAME} DESTINATION /usr/local/lib)
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)


### PR DESCRIPTION
Fixes #5.  This PR refrains from installing things in /usr/local without user consent.